### PR TITLE
Improve prompts and options

### DIFF
--- a/src/PocketBaseClient.CodeGenerator/Extensions/StringExtensions.cs
+++ b/src/PocketBaseClient.CodeGenerator/Extensions/StringExtensions.cs
@@ -20,6 +20,8 @@ namespace PocketBaseClient.CodeGenerator
         private static PluralizationService? _PluralizationService = null;
         private static PluralizationService PluralizationService => _PluralizationService ??= PluralizationService.CreateService(new CultureInfo("en"));
 
+        public static bool SingularizeAndPluralize = false;
+        
         public static string ToPascalCaseForNamespace(this string s)
         {
             var splitted = s.Split('.');
@@ -86,9 +88,9 @@ namespace PocketBaseClient.CodeGenerator
         }
 
         public static string Singularize(this string the_string)
-            => PluralizationService.Singularize(the_string);
+            => SingularizeAndPluralize ? PluralizationService.Singularize(the_string) : the_string;
 
         public static string Pluralize(this string the_string)
-            => PluralizationService.Pluralize(the_string);
+            => SingularizeAndPluralize ? PluralizationService.Pluralize(the_string) : the_string;
     }
 }

--- a/src/PocketBaseClient.CodeGenerator/Extensions/StringExtensions.cs
+++ b/src/PocketBaseClient.CodeGenerator/Extensions/StringExtensions.cs
@@ -27,6 +27,13 @@ namespace PocketBaseClient.CodeGenerator
             var splitted = s.Split('.');
             return string.Join(".", splitted.Select(n => n.ToPascalCase()));
         }
+        public static string ToNamespace(this string s)
+        {
+            var nonWordChars = new Regex(@"[^a-zA-Z0-9]+");
+            var tokens = nonWordChars.Split(s.Trim());
+            return string.Join(".", tokens);
+        }
+
         public static string ToPascalCase(this string s)
         {
             var result = new StringBuilder();

--- a/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
@@ -64,7 +64,7 @@ namespace {settings.NamespaceModels}
             foreach (var value in Options.Values ?? new List<string>())
             {
                 sb.AppendLine(@$"{indent}[Description(""{value}"")]");
-                sb.AppendLine(@$"{indent}{value.Singularize().ToPascalCase()},");
+                sb.AppendLine(@$"{indent}{value},");
                 sb.AppendLine();
             }
             sb.Append($@"

--- a/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
@@ -64,7 +64,7 @@ namespace {settings.NamespaceModels}
             foreach (var value in Options.Values ?? new List<string>())
             {
                 sb.AppendLine(@$"{indent}[Description(""{value}"")]");
-                sb.AppendLine(@$"{indent}{value},");
+                sb.AppendLine(@$"{indent}{value.ToPascalCase()},");
                 sb.AppendLine();
             }
             sb.Append($@"

--- a/src/PocketBaseClient.CodeGenerator/Generation/Generator.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/Generator.cs
@@ -36,6 +36,8 @@ namespace PocketBaseClient.CodeGenerator.Generation
         }
         private void GenerateCodeInternal(Settings settings)
         {
+            StringExtensions.SingularizeAndPluralize = settings.PocketBaseSchema.SingularizeAndPluralize;
+            
             ResetGenerationData();
             foreach (var collectionModel in settings.PocketBaseSchema.Collections)
                 Collections.Add(new CollectionInfo(collectionModel, () => Collections));

--- a/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
+++ b/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
@@ -108,7 +108,7 @@ namespace PocketBaseClient.CodeGenerator.Interactive
                 isOk = !Prompt.Confirm("Do you want to change this project name?", false);
                 if (!isOk)
                     schema.ProjectName = Prompt.Input<string>("Enter the Project Name",
-                        validators: PromptValidators.NameForProjectOrNamespace());
+                        validators: PromptValidators.NameForProjectOrNamespace()).Trim();
             }
         }
 
@@ -119,14 +119,11 @@ namespace PocketBaseClient.CodeGenerator.Interactive
 
             while (!isOk)
             {
-                folder = Prompt.Input<string>("Enter the Directory where create the Project folder with code",
+                folder = Prompt.Input<string>("Enter the Directory where create the Project with code",
                     validators: PromptValidators.ProjectFolder());
                 var dirInfo = new DirectoryInfo(folder);
-                isOk = !dirInfo.Exists;
-                if (!isOk)
-                {
-                    isOk = Prompt.Confirm("The directory already exists, do you want to overwrite this?", false);
-                }
+                isOk = !dirInfo.Exists || 
+                       Prompt.Confirm("The directory already exists, do you want to overwrite this?", false);
             }
 
             return folder;
@@ -142,7 +139,7 @@ namespace PocketBaseClient.CodeGenerator.Interactive
                 isOk = !Prompt.Confirm("Do you want to change this namespace?", false);
                 if (!isOk)
                     schema.Namespace = Prompt.Input<string>("Enter the correct Namespace",
-                        validators: PromptValidators.NameForProjectOrNamespace());
+                        validators: PromptValidators.NameForProjectOrNamespace()).ToNamespace();
             }
         }
 
@@ -151,12 +148,12 @@ namespace PocketBaseClient.CodeGenerator.Interactive
             ConsoleHelper.WriteEmphasis(@"
   This feature may be useful if your collections' name are plural.
   i.e. If you have a collection named ""posts"", 
-       name of class and data service of collection will use pluralized name ""posts"" and
-       name of class of item will use singularized name ""post"".
-       Disabling using this feature, both of it will use ""posts"".
+       name of class and data service of collection will use pluralized name ""Posts"" and
+       name of class of item will use singularized name ""Post"".
+       Disabling using this feature, both of it will use ""Posts"".
 ");
             schema.SingularizeAndPluralize =
-                Prompt.Confirm("Do you want to enable singularize and pluralize feature?", false);
+                Prompt.Confirm("Do you want to enable singularize and pluralize feature?", true);
         }
 
         

--- a/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
+++ b/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
@@ -125,7 +125,7 @@ namespace PocketBaseClient.CodeGenerator.Interactive
 
             while (!isOk)
             {
-                ConsoleHelper.WriteCurrentValue("The namespace for generated code will be:", schema.ProjectName);
+                ConsoleHelper.WriteCurrentValue("The namespace for generated code will be:", schema.Namespace);
                 isOk = !Prompt.Confirm("Do you want to change this namespace?", false);
                 if (!isOk)
                     schema.Namespace = (Prompt.Input<string>("Enter the correct Namespace",

--- a/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
+++ b/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
@@ -53,6 +53,9 @@ namespace PocketBaseClient.CodeGenerator.Interactive
             
             // Ask for the Namespace
             AskNamespace(schema);
+            
+            // Ask for whether to enable singularize and pluralize feature
+            AskSingularizeAndPluralize(schema);
 
             ConsoleHelper.WriteStep(3, "Code generation");
             // Generate code
@@ -141,6 +144,19 @@ namespace PocketBaseClient.CodeGenerator.Interactive
                     schema.Namespace = Prompt.Input<string>("Enter the correct Namespace",
                         validators: PromptValidators.NameForProjectOrNamespace());
             }
+        }
+
+        private static void AskSingularizeAndPluralize(PocketBaseSchema schema)
+        {
+            ConsoleHelper.WriteEmphasis(@"
+  This feature may be useful if your collections' name are plural.
+  i.e. If you have a collection named ""posts"", 
+       name of class and data service of collection will use pluralized name ""posts"" and
+       name of class of item will use singularized name ""post"".
+       Disabling using this feature, both of it will use ""posts"".
+");
+            schema.SingularizeAndPluralize =
+                Prompt.Confirm("Do you want to enable singularize and pluralize feature?", false);
         }
 
         

--- a/src/PocketBaseClient.CodeGenerator/Interactive/PromptValidators.cs
+++ b/src/PocketBaseClient.CodeGenerator/Interactive/PromptValidators.cs
@@ -40,7 +40,7 @@ namespace PocketBaseClient.CodeGenerator.Interactive
             };
         }
 
-        public static List<Func<object, ValidationResult>> BaseDirForProject()
+        public static List<Func<object, ValidationResult>> ProjectFolder()
         {
             return new List<Func<object, ValidationResult>>()
             {
@@ -53,9 +53,6 @@ namespace PocketBaseClient.CodeGenerator.Interactive
                     string strDir = (value as string??string.Empty).Trim();
                     if(string.IsNullOrEmpty(strDir))
                         return new ValidationResult("Value is null or empty");
-
-                    if (!Directory.Exists(Path.GetDirectoryName(strDir)))
-                        return new ValidationResult("Path do not exists");
 
                     return ValidationResult.Success!;
                 },

--- a/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
+++ b/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
@@ -25,7 +25,7 @@ namespace PocketBaseClient.CodeGenerator.Models
         private string? _Namespace = null;
         public string Namespace
         {
-            get => _Namespace ?? ProjectName;
+            get => _Namespace ?? ProjectName.ToNamespace();
             set => _Namespace = value;
         }
 
@@ -34,7 +34,7 @@ namespace PocketBaseClient.CodeGenerator.Models
 
         public DateTime SchemaDate { get; set; } = DateTime.UtcNow;
         
-        public bool SingularizeAndPluralize { get; set; } = false;
+        public bool SingularizeAndPluralize { get; set; } = true;
 
         public List<CollectionModel> Collections { get; set; } = new List<CollectionModel>();
 

--- a/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
+++ b/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
@@ -33,8 +33,11 @@ namespace PocketBaseClient.CodeGenerator.Models
 
 
         public DateTime SchemaDate { get; set; } = DateTime.UtcNow;
+        
+        public bool SingularizeAndPluralize { get; set; } = false;
 
         public List<CollectionModel> Collections { get; set; } = new List<CollectionModel>();
+
 
 
 


### PR DESCRIPTION
This may broaden use cases.
Including,

- 6eaa4196abb57d0a6a2bbd0fdf978d2705212161 : fix issue showing project name instead of namespace when namespace prompt.
- de72777d9cd9f8669998084a62e9332225630643 : 
	- Allow any string for project name and namespace. Microsoft recommends to use PascalCase for namespace. But this is not must-do and users should be allowed to use any string as they want.
	- Allow folder name different from project name. Folder name doesn't necessarily have to be the same with project name.
- 5a915231e917d63c6c9519de306ee10f809d8132 : 
	- fix not to singularize enum field. I think it should not be singularized. I removed that feature but can be optional.
- d0d18bf67626366cf273fe9f390125fd92630d88 :
	- Make singularize and pluralize of collections' name and items' name optional. According to PocketBase documentation, there's no specification to use plural for collection's name. So I made it optional (prompts at first time to generate code).