### PR TITLE
Fix not working relation list

### DIFF
--- a/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoRelation.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoRelation.cs
@@ -79,7 +79,10 @@ namespace {settings.NamespaceModels}
             var list = base.GetLinesForPropertyDecorators();
 
             if (IsMultiple)
+            {
+                list.Add("[JsonInclude]");
                 list.Add($@"[JsonConverter(typeof(RelationListConverter<{ListClassName}, {ReferencedClassName}>))]");
+            } 
             else
                 list.Add($@"[JsonConverter(typeof(RelationConverter<{ReferencedClassName}>))]");
 

--- a/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
@@ -102,7 +102,10 @@ namespace {settings.NamespaceModels}
             var list = base.GetLinesForPropertyDecorators();
 
             if (IsMultiple)
+            {
+                list.Add("[JsonInclude]");
                 list.Add($@"[JsonConverter(typeof(EnumListConverter<{ListClassName}, {EnumName}>))]");
+            }
             else
                 list.Add($@"[JsonConverter(typeof(EnumConverter<{EnumName}>))]");
 

--- a/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
@@ -65,7 +65,7 @@ namespace PocketBaseClient.Orm.Structures
 
         /// <inheritdoc />
         bool IBasicList.Contains(object? element)
-            => false;
+            => element is T item && Contains(item);
 
         /// <inheritdoc />
         public T? Add(T? element)

--- a/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
@@ -82,7 +82,10 @@ namespace PocketBaseClient.Orm.Structures
 
         /// <inheritdoc />
         object? IBasicList.Add(object? element)
-            => null;
+        {
+            return element is T item ? Add(item) : default;
+        }
+
 
         /// <inheritdoc />
         public T? Remove(T? element)
@@ -98,7 +101,9 @@ namespace PocketBaseClient.Orm.Structures
 
         /// <inheritdoc />
         object? IBasicList.Remove(object? element)
-            => null;
+        {
+            return element is T item ? Remove(item) : default;
+        }
 
         /// <inheritdoc />
         public void DiscardChanges(ListSaveDiscardModes mode)

--- a/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
+++ b/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
@@ -26,7 +26,7 @@
 
 Code generated with:
     PocketBaseClient CodeGenerator: pbcodegen v.0.5.0.0
-    At: 2022-12-31T11:18:34.3747882Z
+    At: 2023-01-13T17:54:44.3616804Z
 
 PocketBase Application: 
     Name: demo-test

--- a/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
@@ -85,6 +85,7 @@ namespace PocketBaseClient.DemoTest.Models
         [JsonPropertyName("categories")]
         [PocketBaseField(id: "2ftkqyzs", name: "categories", required: false, system: false, unique: false, type: "relation")]
         [Display(Name = "Categories")]
+        [JsonInclude]
         [JsonConverter(typeof(RelationListConverter<CategoriesList, Category>))]
         public CategoriesList Categories { get => Get(() => _Categories ??= new CategoriesList(this)); private set => Set(value, ref _Categories); }
 
@@ -93,6 +94,7 @@ namespace PocketBaseClient.DemoTest.Models
         [JsonPropertyName("tags")]
         [PocketBaseField(id: "vqnnjaiq", name: "tags", required: false, system: false, unique: false, type: "relation")]
         [Display(Name = "Tags")]
+        [JsonInclude]
         [JsonConverter(typeof(RelationListConverter<TagsList, Tag>))]
         public TagsList Tags { get => Get(() => _Tags ??= new TagsList(this)); private set => Set(value, ref _Tags); }
 

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
@@ -152,6 +152,7 @@ namespace PocketBaseClient.DemoTest.Models
         [JsonPropertyName("select_multiple")]
         [PocketBaseField(id: "8dks1xfy", name: "select_multiple", required: false, system: false, unique: false, type: "select")]
         [Display(Name = "Select_multiple")]
+        [JsonInclude]
         [JsonConverter(typeof(EnumListConverter<SelectMultipleList, SelectMultipleEnum>))]
         public SelectMultipleList SelectMultiple { get => Get(() => _SelectMultiple ??= new SelectMultipleList(this)); private set => Set(value, ref _SelectMultiple); }
 
@@ -203,6 +204,7 @@ namespace PocketBaseClient.DemoTest.Models
         [JsonPropertyName("relation_multiple_no_limit")]
         [PocketBaseField(id: "a4chtr6c", name: "relation_multiple_no_limit", required: false, system: false, unique: false, type: "relation")]
         [Display(Name = "Relation_multiple_no_limit")]
+        [JsonInclude]
         [JsonConverter(typeof(RelationListConverter<RelationMultipleNoLimitList, TestForRelated>))]
         public RelationMultipleNoLimitList RelationMultipleNoLimit { get => Get(() => _RelationMultipleNoLimit ??= new RelationMultipleNoLimitList(this)); private set => Set(value, ref _RelationMultipleNoLimit); }
 
@@ -211,6 +213,7 @@ namespace PocketBaseClient.DemoTest.Models
         [JsonPropertyName("relation_multiple_limit")]
         [PocketBaseField(id: "otxwaoam", name: "relation_multiple_limit", required: false, system: false, unique: false, type: "relation")]
         [Display(Name = "Relation_multiple_limit")]
+        [JsonInclude]
         [JsonConverter(typeof(RelationListConverter<RelationMultipleLimitList, TestForRelated>))]
         public RelationMultipleLimitList RelationMultipleLimit { get => Get(() => _RelationMultipleLimit ??= new RelationMultipleLimitList(this)); private set => Set(value, ref _RelationMultipleLimit); }
 

--- a/src/Test/PocketBaseClient.DemoTest/pbcodegen.json
+++ b/src/Test/PocketBaseClient.DemoTest/pbcodegen.json
@@ -6,6 +6,7 @@
     "appUrl": "https://orm-csharp-test.pockethost.io"
   },
   "SchemaDate": "2022-12-26T09:39:06.2230519Z",
+  "SingularizeAndPluralize": true,
   "Collections": [
     {
       "Id": "_pb_users_auth_",


### PR DESCRIPTION
Hi, when I was using ORM for my project, I found out that list of relation and enum isn't working.
Specifically, CollectionList and EnumList.

There are two reasons that it is not working.
1. JsonSerializer doesn't serialize readonly property.
	CollectionList and EnumList are readonly(setter is private, not public) in auto-generated code. JsonSerializer skips these properties. To include, we need to add `[JsonInclude]` attribute to property explicitly.
2. FieldBasicList doesn't have implementation of `object? IBasicList.Add(object? element)`
	Looks like setter of these properties calls
	`Set` => `UpdateWith` => `Add`
	But FieldBasicList class doesn't have implementation of `object? IBasicList.Add(object? element)`. (returning null)
	I added implementation using FieldBasicList.Add. So that element will be added to the inner list properly.
	(I added implementation of `object? IBasicList.Remove(object? element)` as well because I think it is necessary.)

Also, current implementation of
```C#
        bool IBasicList.Contains(object? element)
            => false;
```
in FieldBasicList class maybe wrong?

I don't fully understand the code so maybe some part are wrong. Sorry for that.