### PR TITLE
Extended filter options

### DIFF
--- a/src/PocketBaseClient/Orm/Filters/FieldFilterDate.cs
+++ b/src/PocketBaseClient/Orm/Filters/FieldFilterDate.cs
@@ -24,6 +24,20 @@ namespace PocketBaseClient.Orm.Filters
         }
 
         /// <summary>
+        /// The Field is Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNull()
+            => new($"{FieldName}=null");
+
+        /// <summary>
+        /// The Field is NOT Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNotNull()
+            => new($"{FieldName}!=null");
+
+        /// <summary>
         /// The Field is Equal to <paramref name="value"/>
         /// </summary>
         /// <param name="value">The value to compare</param>

--- a/src/PocketBaseClient/Orm/Filters/FieldFilterEnumList.cs
+++ b/src/PocketBaseClient/Orm/Filters/FieldFilterEnumList.cs
@@ -31,12 +31,18 @@ namespace PocketBaseClient.Orm.Filters
         }
 
         /// <summary>
-        /// The Field Contains the <paramref name="value"/>
+        /// The Field is Null 
         /// </summary>
-        /// <param name="value">The value to compare</param>
         /// <returns></returns>
-        public FilterCommand Contains(string value)
-            => new($"{FieldName}~'%{value}%'");
+        public FilterCommand IsNull()
+            => new($"{FieldName}=null");
+
+        /// <summary>
+        /// The Field is NOT Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNotNull()
+            => new($"{FieldName}!=null");
 
         /// <summary>
         /// The Field Contains the <paramref name="value"/>
@@ -44,7 +50,7 @@ namespace PocketBaseClient.Orm.Filters
         /// <param name="value">The value to compare</param>
         /// <returns></returns>
         public FilterCommand Contains(T value)
-            => Contains(value.GetDescription() ?? value.ToString()!);
+            => AtLeastOneEqual(value);
 
 
         /// <summary>
@@ -62,5 +68,85 @@ namespace PocketBaseClient.Orm.Filters
         /// <returns></returns>
         public FilterCommand NotContainsl(T value)
             => NotContains(value.GetDescription() ?? value.ToString()!);
+
+        /// <summary>
+        /// In the Field At least One is Equal to <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneEqual(T value)
+            => new($"{FieldName}?='{value}'");
+
+        /// <summary>
+        /// In the Field At least One is NOT Equal to <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneNotEqual(T value)
+            => new($"{FieldName}?!='{value}'");
+
+        /// <summary>
+        /// In the Field At least One is Like to <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneLike(string value)
+            => new($"{FieldName}?~'{value}'");
+
+        /// <summary>
+        /// In the Field At least One is NOT Like to <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneNotLike(string value)
+            => new($"{FieldName}?!~'{value}'");
+
+        /// <summary>
+        /// In the Field At least One Contains <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneContains(string value)
+            => new($"{FieldName}?~'%{value}%'");
+
+        /// <summary>
+        /// In the Field At least One NOT Contains <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneNotContains(string value)
+            => new($"{FieldName}?!~'%{value}%'");
+
+        /// <summary>
+        /// In the Field At least One Starts With <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneStartsWith(string value)
+            => new($"{FieldName}?~'{value}%'");
+
+        /// <summary>
+        /// In the Field At least One NOT Starts With <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneNotStartsWith(string value)
+            => new($"{FieldName}?!~'{value}%'");
+
+        /// <summary>
+        /// In the Field At least One Ends With <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneEndsWith(string value)
+            => new($"{FieldName}?~'%{value}'");
+
+        /// <summary>
+        /// In the Field At least One NOT Ends With <paramref name="value"/>
+        /// </summary>
+        /// <param name="value">The value to compare</param>
+        /// <returns></returns>
+        public FilterCommand AtLeastOneNotEndsWith(string value)
+            => new($"{FieldName}?!~'%{value}'");
     }
 }

--- a/src/PocketBaseClient/Orm/Filters/FieldFilterItem.cs
+++ b/src/PocketBaseClient/Orm/Filters/FieldFilterItem.cs
@@ -24,6 +24,20 @@ namespace PocketBaseClient.Orm.Filters
         public FieldFilterItem(string fieldName) : base(fieldName)
         {
         }
+        
+        /// <summary>
+        /// The Field is Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNull()
+            => new($"{FieldName}=null");
+
+        /// <summary>
+        /// The Field is NOT Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNotNull()
+            => new($"{FieldName}!=null");
 
         /// <summary>
         /// The Field is related to Id Equal to <paramref name="value"/>

--- a/src/PocketBaseClient/Orm/Filters/FieldFilterItemList.cs
+++ b/src/PocketBaseClient/Orm/Filters/FieldFilterItemList.cs
@@ -30,6 +30,20 @@ namespace PocketBaseClient.Orm.Filters
         }
 
         /// <summary>
+        /// The Field is Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNull()
+            => new($"{FieldName}=null");
+
+        /// <summary>
+        /// The Field is NOT Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNotNull()
+            => new($"{FieldName}!=null");
+
+        /// <summary>
         /// The Field Contains a relation to Id <paramref name="value"/>
         /// </summary>
         /// <param name="value">The value to compare</param>
@@ -58,7 +72,7 @@ namespace PocketBaseClient.Orm.Filters
         /// </summary>
         /// <param name="value">The value to compare</param>
         /// <returns></returns>
-        public FilterCommand NotContainsl(T value)
+        public FilterCommand NotContains(T value)
             => NotContainsId(value.Id!);
     }
 }

--- a/src/PocketBaseClient/Orm/Filters/FieldFilterText.cs
+++ b/src/PocketBaseClient/Orm/Filters/FieldFilterText.cs
@@ -24,6 +24,20 @@ namespace PocketBaseClient.Orm.Filters
         }
 
         /// <summary>
+        /// The Field is Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNull()
+            => new($"{FieldName}=null");
+
+        /// <summary>
+        /// The Field is NOT Null 
+        /// </summary>
+        /// <returns></returns>
+        public FilterCommand IsNotNull()
+            => new($"{FieldName}!=null");
+
+        /// <summary>
         /// The Field is Equal to <paramref name="value"/>
         /// </summary>
         /// <param name="value">The value to compare</param>


### PR DESCRIPTION
- `IsNull` and `IsNotNull` in all Pocketbase nullable types
- `AtLeastOneEqual`, `AtLeastOneNotEqual`, `AtLeastOneLike`, `AtLeastOneNotLike`, `AtLeastOneContains`, `AtLeastOneNotContains`, `AtLeastOneStartsWith`, `AtLeastOneNotStartsWith`, `AtLeastOneEndsWith`, `AtLeastOneNotEndsWith` in Pocketbase multiple select type